### PR TITLE
Add memgraph build target

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,7 +1,11 @@
 build:
-	docker build -t mem0-api-server .
+        docker build -t mem0-api-server .
+
+# Build Memgraph image used for graph memory examples
+memgraph-image:
+        docker pull memgraph/memgraph-mage:latest
 
 run_local:
-	docker run -p 8000:8000 -v $(shell pwd):/app mem0-api-server --env-file .env
+        docker run -p 8000:8000 -v $(shell pwd):/app mem0-api-server --env-file .env
 
-.PHONY: build run_local
+.PHONY: build run_local memgraph-image

--- a/server/README.md
+++ b/server/README.md
@@ -15,3 +15,11 @@ Mem0 provides a REST API server (written using FastAPI). Users can perform all o
 ## Running the server
 
 Follow the instructions in the [docs](https://docs.mem0.ai/open-source/features/rest-api) to run the server.
+
+## Development
+
+The `Makefile` in this directory provides helper commands:
+
+- `make build` - build the API server Docker image.
+- `make run_local` - run the server container locally.
+- `make memgraph-image` - pull the Memgraph image used when experimenting with graph memory.


### PR DESCRIPTION
## Summary
- extend the server Makefile with a `memgraph-image` target to pull the Memgraph image
- document new Makefile commands in server README

## Testing
- `make test` *(fails: hatch not found)*