### PR TITLE
Fix Makefile target declarations

### DIFF
--- a/openmemory/Makefile
+++ b/openmemory/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down logs shell migrate test test-clean env ui-install ui-start ui-dev ui-build ui-dev-start memgraph-image
+.PHONY: help up down logs shell migrate upgrade downgrade test test-clean env ui-install ui-start ui-dev ui-build ui-dev-start memgraph-image build
 
 NEXT_PUBLIC_USER_ID=$(USER)
 NEXT_PUBLIC_API_URL=http://localhost:8765
@@ -17,18 +17,18 @@ help:
 	@echo "  make ui-install - Install frontend dependencies"
 	@echo "  make ui-start  - Start the frontend development server"
 	@echo "  make ui-dev    - Install dependencies and start the frontend in dev mode"
-        @echo "  make ui        - Install dependencies and start the frontend in production mode"
-        @echo "  make memgraph-image - Pull Memgraph image for graph memory"
+	@echo "  make ui        - Install dependencies and start the frontend in production mode"
+	@echo "  make memgraph-image - Pull Memgraph image for graph memory"
 
 env:
 	cd api && cp .env.example .env
 	cd ui && cp .env.example .env
 
 build: memgraph-image
-        docker compose build
+	docker compose build
 
 memgraph-image:
-        docker pull memgraph/memgraph-mage:latest
+	docker pull memgraph/memgraph-mage:latest
 
 up:
 	NEXT_PUBLIC_USER_ID=$(USER) NEXT_PUBLIC_API_URL=$(NEXT_PUBLIC_API_URL) docker compose up


### PR DESCRIPTION
## Summary
- declare more Make targets as `.PHONY`
- ensure build runs without missing-separator error by using tabs for commands

## Testing
- `make test` *(fails: hatch not installed)*
- `make -n build` in `openmemory`