### PR TITLE
Add Memory Bank docs

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,6 @@
+# Cline Rules
+
+- Maintain memory-bank documentation as the primary source of project context.
+- Python is used for backend (FastAPI server, library). Avoid introducing new frameworks.
+- Use Docker and Docker Compose for local setup, including Memgraph for graph memory.
+- Tests are written in Python and should be run with `pytest`.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,7 @@
+# Active Context
+
+Current focus: set up the memory bank documentation for this repository. This includes creating the initial markdown files that summarize project goals and architecture.
+
+Recent changes: Added the memory-bank directory with projectbrief, productContext, systemPatterns, techContext, progress and this activeContext. Created root .clinerules for patterns.
+
+Next steps: update these files as development progresses and keep progress.md current.

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,5 @@
+# Product Context
+
+Mem0 exists to give AI applications a reliable long term memory. Many LLM based systems lose context over time or across sessions. Mem0 solves this by storing important information in a dual storage architecture and retrieving it via semantic search. The library is used to personalize assistants, support bots and other agents.
+
+Users should experience more consistent and helpful interactions because past conversations and preferences are remembered. Developers interact through simple add and search operations using the SDKs or REST API.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,7 @@
+# Progress
+
+Implemented core memory operations and API endpoints. OpenMemory provides a reference server and UI that run with Docker. Tests exist for major modules.
+
+Current status: memory bank documentation added. No outstanding build tasks at this time.
+
+Known issues: none captured yet.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,10 @@
+# Project Brief
+
+Mem0 is an open source memory layer that augments AI assistants and agents with persistent, contextual memory. The goal is to provide easy to use APIs and SDKs so applications can store, search and manage memories over time. It supports multi level memory for user, session and agent state and integrates with various LLMs.
+
+Key objectives:
+- Deliver a scalable memory system that works with vector and graph databases for efficient storage and retrieval.
+- Provide Python and JavaScript SDKs plus REST API for integration.
+- Offer both a hosted platform and self-hosted option.
+
+These goals are derived from the README and docs.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,5 @@
+# System Patterns
+
+Mem0 uses a dual storage design composed of a vector database for memories and a graph database for relationships. LLMs extract key information from conversations, and memories are retrieved using semantic search with optional graph queries. The main API exposes `add` and `search` operations.
+
+The repository includes a Python package, a REST API server using FastAPI, and optional UI under OpenMemory. Docker is used for local development with Memgraph as the graph database.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,8 @@
+# Tech Context
+
+- Primary language: Python, packaging via poetry
+- REST API built with FastAPI (server/ directory)
+- Optional frontend in React/Next.js under openmemory/ui
+- Requires Docker and Docker Compose for local dev
+- Depends on Memgraph for graph memory and various vector databases
+- LLM support via OpenAI by default


### PR DESCRIPTION
## Summary
- document project overview and tech context in `memory-bank/`
- add `.clinerules` with working notes

## Testing
- `make test` *(fails: hatch not found)*