### PR TITLE
Fix openmemory Makefile rule

### DIFF
--- a/openmemory/Makefile
+++ b/openmemory/Makefile
@@ -53,7 +53,7 @@ downgrade:
 	docker compose exec api alembic downgrade -1
 
 ui-dev:
-        cd ui && NEXT_PUBLIC_USER_ID=$(USER) NEXT_PUBLIC_API_URL=$(NEXT_PUBLIC_API_URL) pnpm install && pnpm dev
+	cd ui && NEXT_PUBLIC_USER_ID=$(USER) NEXT_PUBLIC_API_URL=$(NEXT_PUBLIC_API_URL) pnpm install && pnpm dev
 
 jarvis: memgraph-image
 	cp api/jarvis.env api/.env


### PR DESCRIPTION
## Summary
- fix indentation on the `ui-dev` rule in `openmemory/Makefile`

## Testing
- `make build` *(fails: `docker: No such file or directory`)*
- `make test` in openmemory (no test target)